### PR TITLE
2017 06 rq/web print screen zb

### DIFF
--- a/npg_bank_account_reconciliation/npg_bank_account_reconciliation.py
+++ b/npg_bank_account_reconciliation/npg_bank_account_reconciliation.py
@@ -226,6 +226,12 @@ class bank_acc_rec_statement(osv.osv):
 #                 domain += [('date', '<=', ending_date)]
             if context.get('start_date'):
                 domain += [('date', '>=', context.get('start_date'))]
+                
+            #Diarios de apertura
+            journal_ids = self.pool.get('account.journal').search(cr, uid, [('type','=','situation')], context=context)
+            if not context.get('opening_entries'):
+                domain += [('journal_id', 'not in', journal_ids)]
+               
             line_ids = account_move_line_obj.search(cr, uid, domain, context=context)
             for line in account_move_line_obj.browse(cr, uid, line_ids, context=context):
                 res = {

--- a/web_printscreen_zb/__openerp__.py
+++ b/web_printscreen_zb/__openerp__.py
@@ -32,6 +32,7 @@
     'depends': ['web'],
     'js': ['static/src/js/web_printscreen_export.js'],
     'qweb': ['static/src/xml/web_printscreen_export.xml'],
+    'css' : ["static/src/css/base.css"],
     'installable': True,
     'auto_install': False,
     'web_preload': False,

--- a/web_printscreen_zb/controllers.py
+++ b/web_printscreen_zb/controllers.py
@@ -90,7 +90,7 @@ class ZbExcelExport(ExcelExport):
         return req.make_response(
             self.from_data(data.get('headers', []), data.get('rows', [])),
                            headers=[
-                                    ('Content-Disposition', 'attachment; filename="%s"'
+                                    ('Content-Disposition', 'attachment; filename="%s.xls"'
                                         % data.get('model', 'Export.xls')),
                                     ('Content-Type', self.content_type)
                                     ],

--- a/web_printscreen_zb/static/src/css/base.css
+++ b/web_printscreen_zb/static/src/css/base.css
@@ -1,0 +1,6 @@
+.openerp .oe_form .oe_form_field_one2many > .oe_view_manager .oe_list_pager_single_page {
+  display: block;
+}
+.openerp .oe_form_field_one2many > .oe_view_manager .oe_list_pager_single_page, .openerp .oe_form_field_many2many > .oe_view_manager .oe_list_pager_single_page {
+  display: block !important;
+}


### PR DESCRIPTION
Corrección de extensión de la descarga en excel
Evitar que se oculten los botones de exportar cuando el límite es mayor que el total