### PR TITLE
[FIX] web_printscreen_zb : Se agrega extensión xls

### DIFF
--- a/web_printscreen_zb/__openerp__.py
+++ b/web_printscreen_zb/__openerp__.py
@@ -32,6 +32,7 @@
     'depends': ['web'],
     'js': ['static/src/js/web_printscreen_export.js'],
     'qweb': ['static/src/xml/web_printscreen_export.xml'],
+    'css' : ["static/src/css/base.css"],
     'installable': True,
     'auto_install': False,
     'web_preload': False,

--- a/web_printscreen_zb/controllers.py
+++ b/web_printscreen_zb/controllers.py
@@ -90,7 +90,7 @@ class ZbExcelExport(ExcelExport):
         return req.make_response(
             self.from_data(data.get('headers', []), data.get('rows', [])),
                            headers=[
-                                    ('Content-Disposition', 'attachment; filename="%s"'
+                                    ('Content-Disposition', 'attachment; filename="%s.xls"'
                                         % data.get('model', 'Export.xls')),
                                     ('Content-Type', self.content_type)
                                     ],

--- a/web_printscreen_zb/static/src/css/base.css
+++ b/web_printscreen_zb/static/src/css/base.css
@@ -1,0 +1,6 @@
+.openerp .oe_form .oe_form_field_one2many > .oe_view_manager .oe_list_pager_single_page {
+  display: block;
+}
+.openerp .oe_form_field_one2many > .oe_view_manager .oe_list_pager_single_page, .openerp .oe_form_field_many2many > .oe_view_manager .oe_list_pager_single_page {
+  display: block !important;
+}


### PR DESCRIPTION
La exportación excel para que se descargue con el formato correcto, se extiende la css del pager para evitar que se oculte el pager