### PR TITLE
[FIX][aditmaq]: ADD 4 Permisos de acceso.

### DIFF
--- a/bi_crm_claim/models/crm_claim.py
+++ b/bi_crm_claim/models/crm_claim.py
@@ -110,7 +110,7 @@ class res_partner(models.Model):
     @api.multi
     def _claim_count(self):
         for claim in self:
-            claim_ids = self.env['crm.claim'].search([('partner_id','=',claim.id)])
+            claim_ids = self.env['crm.claim'].sudo().search([('partner_id','=',claim.id)])
             claim.claim_count = len(claim_ids)
             
     @api.multi


### PR DESCRIPTION
Se corrige la falta de acceso a la vista "form" de "Proveedores" desde
un usuario que no tenga permiso en crm.claim.

Problema: la tabla "crm.claim" se relaciona con "res.partner" y en la
vista hay un campo computado "claim_count" que cuenta la cantidad de
registros (reclamos) y el usuario sin permisos no puede acceder a estos.

Solucion: Al search() del metodo se le agrega el metodo "sudo()" para que el usuario actual pueda buscar la lista de reclamos como Administrador/SuperUsuario.