### PR TITLE
[IMP][bi_crm_claim]: Traducciones restantes.

### DIFF
--- a/bi_crm_claim/i18n/es.po
+++ b/bi_crm_claim/i18n/es.po
@@ -28,7 +28,7 @@ msgstr "Acciones"
 #. module: bi_crm_claim
 #: model:ir.ui.menu,name:bi_crm_claim.menu_aftersale
 msgid "After-Sale"
-msgstr "Después de la venta"
+msgstr "Post-Venta"
 
 #. module: bi_crm_claim
 #: model:ir.ui.menu,name:bi_crm_claim.menu_crm_case_claim-act

--- a/bi_crm_claim/models/crm_claim.py
+++ b/bi_crm_claim/models/crm_claim.py
@@ -54,7 +54,7 @@ class crm_claim(models.Model):
     date = fields.Datetime('Claim Date', select=True,default=lambda self: self._context.get('date', fields.Date.context_today(self)))
     categ_id = fields.Many2one('crm.claim.category', 'Category')
     priority = fields.Selection([('0','Low'), ('1','Normal'), ('2','High')], 'Priority',default='1')
-    type_action = fields.Selection([('correction','Corrective Action'),('prevention','Preventive Action')], 'Action Type')
+    type_action = fields.Selection([('correction','Corrective Action'),('prevention','Preventive Action')], 'Tipo de acción')
     user_id = fields.Many2one('res.users', 'Responsible', track_visibility='always',default=lambda self: self.env.user)
     user_fault = fields.Char('Trouble Responsible')
     team_id = fields.Many2one('crm.team', 'Sales Team', oldname='section_id',\
@@ -131,4 +131,4 @@ class crm_claim_category(models.Model):
     _description = "Category of claim"
 
     name = fields.Char('Name', required=True, translate=True)
-    team_id = fields.Many2one('crm.team', 'Sales Team')
+    team_id = fields.Many2one('crm.team', 'Equipo de ventas')


### PR DESCRIPTION
Se traduce desde i18n:

	- Despues de la Venta -> Post-Venta

Se traduce desde models:

	- Sales Team -> Equipo de ventas
	- Action Type -> Tipo de acción
	
PD: Se aclara que en la vista "Ventas/Clientes", el boton/contador de reclamos es invisible si la cantidad de reclamos es igual a cero (0) y se muestra en caso contrario.