### PR TITLE
[IMP][bi_crm_claim]: Traducciones restantes.

### DIFF
--- a/bi_crm_claim/i18n/es.po
+++ b/bi_crm_claim/i18n/es.po
@@ -28,7 +28,7 @@ msgstr "Acciones"
 #. module: bi_crm_claim
 #: model:ir.ui.menu,name:bi_crm_claim.menu_aftersale
 msgid "After-Sale"
-msgstr "Después de la venta"
+msgstr "Post-Venta"
 
 #. module: bi_crm_claim
 #: model:ir.ui.menu,name:bi_crm_claim.menu_crm_case_claim-act

--- a/bi_crm_claim/models/crm_claim.py
+++ b/bi_crm_claim/models/crm_claim.py
@@ -54,7 +54,7 @@ class crm_claim(models.Model):
     date = fields.Datetime('Claim Date', select=True,default=lambda self: self._context.get('date', fields.Date.context_today(self)))
     categ_id = fields.Many2one('crm.claim.category', 'Category')
     priority = fields.Selection([('0','Low'), ('1','Normal'), ('2','High')], 'Priority',default='1')
-    type_action = fields.Selection([('correction','Corrective Action'),('prevention','Preventive Action')], 'Action Type')
+    type_action = fields.Selection([('correction','Corrective Action'),('prevention','Preventive Action')], 'Tipo de acción')
     user_id = fields.Many2one('res.users', 'Responsible', track_visibility='always',default=lambda self: self.env.user)
     user_fault = fields.Char('Trouble Responsible')
     team_id = fields.Many2one('crm.team', 'Sales Team', oldname='section_id',\
@@ -131,4 +131,4 @@ class crm_claim_category(models.Model):
     _description = "Category of claim"
 
     name = fields.Char('Name', required=True, translate=True)
-    team_id = fields.Many2one('crm.team', 'Sales Team')
+    team_id = fields.Many2one('crm.team', 'Equipo de ventas')

--- a/bi_crm_claim/models/crm_claim.py
+++ b/bi_crm_claim/models/crm_claim.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import api, fields, models, _
 from itertools import groupby
 from datetime import datetime, timedelta
 
-from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.tools import float_is_zero, float_compare, DEFAULT_SERVER_DATETIME_FORMAT
 from odoo.tools.misc import formatLang
@@ -54,7 +54,7 @@ class crm_claim(models.Model):
     date = fields.Datetime('Claim Date', select=True,default=lambda self: self._context.get('date', fields.Date.context_today(self)))
     categ_id = fields.Many2one('crm.claim.category', 'Category')
     priority = fields.Selection([('0','Low'), ('1','Normal'), ('2','High')], 'Priority',default='1')
-    type_action = fields.Selection([('correction','Corrective Action'),('prevention','Preventive Action')], 'Tipo de acción')
+    type_action = fields.Selection([('correction','Corrective Action'),('prevention','Preventive Action')], string='Tipo de acción')
     user_id = fields.Many2one('res.users', 'Responsible', track_visibility='always',default=lambda self: self.env.user)
     user_fault = fields.Char('Trouble Responsible')
     team_id = fields.Many2one('crm.team', 'Sales Team', oldname='section_id',\
@@ -131,4 +131,4 @@ class crm_claim_category(models.Model):
     _description = "Category of claim"
 
     name = fields.Char('Name', required=True, translate=True)
-    team_id = fields.Many2one('crm.team', 'Equipo de ventas')
+    team_id = fields.Many2one('crm.team', string='Equipo de ventas')

--- a/bi_crm_claim/views/crm_claim_menu.xml
+++ b/bi_crm_claim/views/crm_claim_menu.xml
@@ -21,7 +21,7 @@
                 <form string="Claim Categories">
                     <group>
                         <field name="name"/>
-                        <field name="team_id"/>
+                        <field name="team_id" string="Equipo de ventas"/>
                     </group>
                 </form>
             </field>
@@ -33,7 +33,7 @@
             <field name="arch" type="xml">
                 <tree string="Claim Categories">
                     <field name="name"/>
-                    <field name="team_id"/>
+                    <field name="team_id" string="Equipo de ventas"/>
                 </tree>
             </field>
         </record>
@@ -140,7 +140,7 @@
                     <group colspan="4" col="4" groups="base.group_user">
                         <field name="user_id" context="{'default_groups_ref': ['base.group_user', 'base.group_partner_manager']}"/>
                         <field name="priority" widget="priority"/>
-                        <field name="team_id"/>
+                        <field name="team_id" string="Equipo de ventas"/>
                         <field name="date_deadline"/>
                     </group>
                     <group colspan="4" col="4">

--- a/bi_crm_claim/views/crm_claim_view.xml
+++ b/bi_crm_claim/views/crm_claim_view.xml
@@ -14,7 +14,7 @@
                 <form string="Claim Categories">
                     <group>
                         <field name="name"/>
-                        <field name="team_id"/>
+                        <field name="team_id" string="Equipo de ventas"/>
                     </group>
                 </form>
             </field>
@@ -26,7 +26,7 @@
             <field name="arch" type="xml">
                 <tree string="Claim Categories">
                     <field name="name"/>
-                    <field name="team_id"/>
+                    <field name="team_id" string="Equipo de ventas"/>
                 </tree>
             </field>
         </record>
@@ -130,7 +130,7 @@
                     <group colspan="4" col="4">
                         <field name="user_id" />
                         <field name="priority" widget="priority"/>
-                        <field name="team_id"/>
+                        <field name="team_id" string="Equipo de ventas"/>
                         <field name="date_deadline"/>
                     </group>
                     <group colspan="4" col="4">


### PR DESCRIPTION
    Se traduce desde i18n:

        - Despues de la Venta -> Post-Venta

    Se traduce desde models:

        - Sales Team -> Equipo de ventas (Desde aqui no se observan cambios, por lo tanto se realiza desde views).
        - Action Type -> Tipo de acción

    Se traduce desde views:

        - Sales Team -> Equipo de ventas

    PD: Se aclara que en la vista "Ventas/Clientes", el boton/contador de reclamos es invisible si la cantidad de reclamos es igual a cero (0) y se muestra en caso contrario.